### PR TITLE
Run benchmarks with the exe compiler

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -9,3 +9,5 @@ presets:
   benchmark:
     include_tags: benchmark
     concurrency: 1
+    compilers:
+      - exe


### PR DESCRIPTION
This is better for benchmarks because it doesn't do optimization as it runs like the JIT (kernel compiler) will, so it produces more consistent results and you don't run the risk of your benchmarks appearing to get faster just because they ran after other benchmarks.